### PR TITLE
Change separator in itemsets

### DIFF
--- a/src/FPGrowth.php
+++ b/src/FPGrowth.php
@@ -10,6 +10,7 @@ class FPGrowth
 {
     protected int $support = 3;
     protected float $confidence = 0.7;
+    private int $maxLength = 0;
 
     private $patterns;
     private $rules;
@@ -50,6 +51,15 @@ class FPGrowth
         return $this;
     }
 
+    public function getMaxLength(): int
+    {
+        return $this->maxLength;
+    }
+
+    public function setMaxLength(int $maxLength): void
+    {
+        $this->maxLength = $maxLength;
+    }
     /**
      * @return mixed
      */
@@ -71,10 +81,11 @@ class FPGrowth
      * @param int $support 1, 2, 3 ...
      * @param float $confidence 0 ... 1
      */
-    public function __construct(int $support, float $confidence)
+    public function __construct(int $support, float $confidence, int $maxLength = 0)
     {
         $this->setSupport($support);
         $this->setConfidence($confidence);
+        $this->setMaxLength($maxLength);
     }
 
     /**
@@ -93,7 +104,7 @@ class FPGrowth
      */
     protected function findFrequentPatterns(array $transactions): array
     {
-        $tree = new FPTree($transactions, $this->support, null, 0);
+        $tree = new FPTree($transactions, $this->support, null, 0, $this->maxLength);
         return $tree->minePatterns($this->support);
     }
 

--- a/src/FPTree.php
+++ b/src/FPTree.php
@@ -18,7 +18,9 @@ class FPTree
 
     private int $maxLength = 0;
 
-    private int $depth = 0;
+    private string $itemsetSeparator;
+
+    private int    $depth = 0;
 
     /**
      * Initialize the tree.
@@ -27,12 +29,13 @@ class FPTree
      * @param $rootValue
      * @param int $rootCount
      */
-    public function __construct(array $transactions, int $threshold, $rootValue, int $rootCount, $maxLength = 0)
+    public function __construct(array $transactions, int $threshold, $rootValue, int $rootCount, $maxLength = 0, string $itemsetSeparator = "\0")
     {
         $this->frequent = $this->findFrequentItems($transactions, $threshold);
         $this->headers = $this->buildHeaderTable();
         $this->root = $this->buildFPTree($transactions, $rootValue, $rootCount, $this->frequent);
         $this->maxLength = $maxLength;
+        $this->itemsetSeparator = $itemsetSeparator;
     }
 
     /**
@@ -195,10 +198,10 @@ class FPTree
         // We are in a conditional tree.
         $newPatterns = [];
         foreach (array_keys($patterns) as $strKey) {
-            $key = explode(',', $strKey);
+            $key = explode($this->itemsetSeparator, $strKey);
             $key[] = $this->root->value;
             sort($key);
-            $newPatterns[implode(',', $key)] = $patterns[$strKey];
+            $newPatterns[implode($this->itemsetSeparator, $key)] = $patterns[$strKey];
         }
 
         return $newPatterns;
@@ -236,7 +239,7 @@ class FPTree
                         $min = $this->frequent[$x];
                     }
                 }
-                $patterns[implode(',', $pattern)] = $min;
+                $patterns[implode($this->itemsetSeparator, $pattern)] = $min;
             }
         }
 


### PR DESCRIPTION
The implementation uses commas internally to separate items in itemsets. This is a problem if the item contains a comma itself.

The separator is now configurable and a null byte by default. It is only used internally.

(based upon https://github.com/EnzoMC/php-fpgrowth/pull/4 which should be merged first)